### PR TITLE
feat: add /events and /speak pages

### DIFF
--- a/app/components/Aside.css.ts
+++ b/app/components/Aside.css.ts
@@ -1,0 +1,19 @@
+import { style } from "@vanilla-extract/css";
+
+export const aside = style({
+	"::before": {
+		alignItems: "center",
+		bottom: 0,
+		content: "💡",
+		display: "flex",
+		fontStyle: "initial",
+		left: 0,
+		position: "absolute",
+		top: 0,
+	},
+	fontStyle: "italic",
+	fontWeight: "normal",
+	margin: "3rem 0 1rem",
+	paddingLeft: "3rem",
+	position: "relative",
+});

--- a/app/components/Aside.tsx
+++ b/app/components/Aside.tsx
@@ -1,0 +1,12 @@
+import clsx from "clsx";
+import React from "react";
+
+import * as styles from "./Aside.css";
+
+export interface AsideProps extends React.PropsWithChildren {
+	className?: string;
+}
+
+export function Aside({ children, className }: AsideProps) {
+	return <aside className={clsx(styles.aside, className)}>{children}</aside>;
+}

--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -5,10 +5,11 @@ import { AnchorWithArrow } from "./AnchorWithArrow";
 import * as styles from "./EventDetails.css";
 
 export interface EventDetailsProps {
+	active?: boolean;
 	event: EventData;
 }
 
-export function EventDetails({ event }: EventDetailsProps) {
+export function EventDetails({ active, event }: EventDetailsProps) {
 	const formatter = new Intl.DateTimeFormat(region.locale, {
 		day: "numeric",
 		month: "long",
@@ -24,7 +25,9 @@ export function EventDetails({ event }: EventDetailsProps) {
 					<li key={topic}>{topic}</li>
 				))}
 			</ul>
-			<AnchorWithArrow href={event.link}>Register Now</AnchorWithArrow>
+			<AnchorWithArrow href={event.link}>
+				{active ? "Register Now" : "Event Info"}
+			</AnchorWithArrow>
 		</article>
 	);
 }

--- a/app/components/EventsList.css.ts
+++ b/app/components/EventsList.css.ts
@@ -15,5 +15,5 @@ export const heading = style({
 export const events = style({
 	display: "flex",
 	flexDirection: "column",
-	gap: "2rem",
+	gap: "3rem",
 });

--- a/app/components/EventsList.css.ts
+++ b/app/components/EventsList.css.ts
@@ -11,3 +11,9 @@ export const heading = style({
 
 	margin: "clamp(0.5rem, 2.5vh, 3rem) 0",
 });
+
+export const events = style({
+	display: "flex",
+	flexDirection: "column",
+	gap: "2rem",
+});

--- a/app/components/EventsList.tsx
+++ b/app/components/EventsList.tsx
@@ -5,19 +5,25 @@ import * as styles from "./EventsList.css";
 import { Heading } from "./Heading";
 
 export interface EventsListProps {
+	active?: boolean;
+	descriptor: string;
 	events: EventData[];
 }
 
-export function EventsList({ events }: EventsListProps) {
+export function EventsList({ active, descriptor, events }: EventsListProps) {
 	return (
 		<>
 			<Heading className={styles.heading} level={2}>
-				Upcoming Event{events.length === 1 ? "" : "s"}
+				{descriptor} Event{events.length === 1 ? "" : "s"}
 			</Heading>
 
-			{events.length
-				? events.map((event) => <EventDetails event={event} key={event.link} />)
-				: "Still in the works. Let us know if you'd like to help organize!"}
+			<div className={styles.events}>
+				{events.length
+					? events.map((event) => (
+							<EventDetails active={active} event={event} key={event.link} />
+						))
+					: "Still in the works. Let us know if you'd like to help organize!"}
+			</div>
 		</>
 	);
 }

--- a/app/components/EventsList.tsx
+++ b/app/components/EventsList.tsx
@@ -6,7 +6,7 @@ import { Heading } from "./Heading";
 
 export interface EventsListProps {
 	active?: boolean;
-	descriptor: string;
+	descriptor: "All" | "Upcoming";
 	events: EventData[];
 }
 

--- a/app/components/Layout.css.ts
+++ b/app/components/Layout.css.ts
@@ -52,7 +52,7 @@ export const footerLinks = style({
 		[breakpoints.medium]: {
 			alignItems: "flex-end",
 			flexDirection: "row",
-			justifyContent: "flex-end",
+			justifyContent: "space-between",
 			textAlign: "right",
 		},
 	},

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -44,6 +44,15 @@ export function Layout({ back, children, title }: LayoutProps) {
 						Code of Conduct
 					</InternalAnchor>
 				</div>
+				<div className={styles.footerLinks}>
+					<InternalAnchor reloadDocument to="/events" variant="heavy">
+						Previous Events
+					</InternalAnchor>
+					<span className={styles.dot} />
+					<InternalAnchor reloadDocument to="/speak" variant="heavy">
+						Speak
+					</InternalAnchor>
+				</div>
 				<SocialsList />
 			</footer>
 		</div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -37,7 +37,11 @@ export default function Index() {
 
 	return (
 		<Layout title={["Boston", "TS Club"]}>
-			<EventsList events={events.map((event) => eventSchema.parse(event))} />
+			<EventsList
+				active
+				descriptor="Upcoming"
+				events={events.map((event) => eventSchema.parse(event))}
+			/>
 		</Layout>
 	);
 }

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -1,0 +1,31 @@
+import { useLoaderData } from "@remix-run/react";
+import { MetaFunction, json } from "@vercel/remix";
+
+import { EventsList } from "~/components/EventsList";
+import { Layout } from "~/components/Layout";
+import { createMeta } from "~/config";
+import { eventSchema } from "~/schemas";
+
+export const loader = async () => {
+	const events = (await import("../data/events.json")).default.map((event) => ({
+		...event,
+		date: new Date(event.date),
+	}));
+
+	return json(events.sort((a, b) => b.date.getTime() - a.date.getTime()));
+};
+
+export const meta: MetaFunction = () => createMeta({ page: "Events" });
+
+export default function About() {
+	const events = useLoaderData<typeof loader>();
+
+	return (
+		<Layout back title="Events">
+			<EventsList
+				descriptor="All"
+				events={events.map((event) => eventSchema.parse(event))}
+			/>
+		</Layout>
+	);
+}

--- a/app/routes/speak.tsx
+++ b/app/routes/speak.tsx
@@ -1,0 +1,56 @@
+import { MetaFunction } from "@remix-run/node";
+
+import { InternalAnchor } from "~/components/Anchor";
+import { AnchorWithArrow } from "~/components/AnchorWithArrow";
+import { Aside } from "~/components/Aside";
+import { BodyText } from "~/components/BodyText";
+import { Heading } from "~/components/Heading";
+import { Layout } from "~/components/Layout";
+import { createMeta } from "~/config";
+
+const tagline = `No prior experience or TypeScript expertise required!`;
+
+export const meta: MetaFunction = () => createMeta({ page: "Speak", tagline });
+
+export default function About() {
+	return (
+		<Layout back title="Speak">
+			<Heading level={2}>Speak at Boston TS Club</Heading>
+			<BodyText>{tagline}</BodyText>
+			<BodyText>
+				We're looking for anything of interest to TypeScript developers,
+				including non-TypeScript general points. See:
+			</BodyText>
+			<BodyText>
+				<AnchorWithArrow
+					href="https://docs.google.com/forms/d/1QhKIccKVMhEw3htkjwL78190GDFOaYYPAYdcxyLI4AQ"
+					rel="noreferrer"
+					target="_blank"
+				>
+					Boston TS Club Speaking Form
+				</AnchorWithArrow>
+			</BodyText>
+			<BodyText>
+				All we ask is:
+				<ul>
+					<li>
+						Send us your slides 24 hours in advance, so we can check them for
+						accessibility
+					</li>
+					<li>Be prepared to chat about your talk with attendees</li>
+				</ul>
+			</BodyText>
+			<BodyText>
+				We're happy to give you all the support you need for a great experience,
+				including talk ideation, slides review, and feedback on a dry run. 💙
+			</BodyText>
+			<Aside>
+				Tip: see{" "}
+				<InternalAnchor to="/events" variant="underline">
+					Events
+				</InternalAnchor>{" "}
+				for references of past talks others have given.
+			</Aside>
+		</Layout>
+	);
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #282; fixes #283
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds both pages because I really wanted an even distribution of links in the footer 😄 

<img width="546" alt="Screenshot of the website footer with two rows of links: About, Code of Conduct; Previous Events, Speak" src="https://github.com/SquiggleTools/boston-ts-website/assets/3335181/377eb90e-1123-4b3b-84d2-75fb5798487b">
