### PR TITLE
fix: rename `InternalAnchor`/`ExternalAnchor` prop types

### DIFF
--- a/app/components/Anchor.tsx
+++ b/app/components/Anchor.tsx
@@ -5,7 +5,7 @@ import * as styles from "./Anchor.css";
 
 export type AnchorVariant = keyof typeof styles.anchor;
 
-export interface ExternalAnchorProps extends NavLinkProps {
+export interface InternalAnchorProps extends NavLinkProps {
 	variant: AnchorVariant;
 }
 
@@ -13,13 +13,13 @@ export function InternalAnchor({
 	className,
 	variant,
 	...props
-}: ExternalAnchorProps) {
+}: InternalAnchorProps) {
 	return (
 		<NavLink {...props} className={clsx(styles.anchor[variant], className)} />
 	);
 }
 
-export interface InternalAnchorProps
+export interface ExternalAnchorProps
 	extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	variant: AnchorVariant;
 }
@@ -28,6 +28,6 @@ export function ExternalAnchor({
 	className,
 	variant,
 	...props
-}: InternalAnchorProps) {
+}: ExternalAnchorProps) {
 	return <a {...props} className={clsx(styles.anchor[variant], className)} />;
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: not quite an issue, but this was discussed [here](https://github.com/SquiggleTools/boston-ts-website/pull/284#discussion_r1656539369)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This was identified as a typo in https://github.com/SquiggleTools/boston-ts-website/pull/284#discussion_r1656539369
