### PR TITLE
fix: improve accessibility of links by adding an underline

### DIFF
--- a/app/raw.css
+++ b/app/raw.css
@@ -29,5 +29,4 @@ p {
 :link,
 :visited {
 	color: inherit;
-	text-decoration: none;
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Essentially, per WCAG 2.1 Techniques:

> Link underlines or some other non-color visual distinction are required (when the links are discernible to those with color vision).

References:
- https://www.w3.org/WAI/WCAG21/Techniques/failures/F73
- https://accessibleweb.com/question-answer/do-links-need-to-be-underlined/
- https://webaim.org/techniques/hypertext/link_text

We might also want to consider a different color for links: https://www.w3.org/WAI/WCAG21/Techniques/general/G183

Before | After
--- | ---
<img width="1512" alt="Screenshot 2024-06-28 at 02 05 54" src="https://github.com/SquiggleTools/boston-ts-website/assets/113730/e4a4d605-7ea5-4c7f-b86c-b4ea10cdb32f"> | <img width="1512" alt="Screenshot 2024-06-28 at 02 06 08" src="https://github.com/SquiggleTools/boston-ts-website/assets/113730/d10c77e9-7ddb-45cc-ba6d-b29c6f5924e0">
