### PR TITLE
feat: format dates to include week day and year

### DIFF
--- a/app/components/EventDetails.tsx
+++ b/app/components/EventDetails.tsx
@@ -10,15 +10,18 @@ export interface EventDetailsProps {
 }
 
 export function EventDetails({ active, event }: EventDetailsProps) {
-	const formatter = new Intl.DateTimeFormat(region.locale, {
-		day: "numeric",
-		month: "long",
-		timeZone: region.timeZone,
-	});
+	function formatDate(date: Date) {
+		const weekday = date.toLocaleString(region.locale, { weekday: "long" });
+		const day = date.toLocaleString(region.locale, { day: "numeric" });
+		const month = date.toLocaleString(region.locale, { month: "long" });
+		const year = date.toLocaleString(region.locale, { year: "numeric" });
+
+		return `${weekday} ${day} ${month} ${year}`;
+	}
 
 	return (
 		<article className={styles.article}>
-			<h3 className={styles.heading}>{formatter.format(event.date)}</h3>
+			<h3 className={styles.heading}>{formatDate(event.date)}</h3>
 			<div>{event.location}</div>
 			<ul className={styles.list}>
 				{event.topics.map((topic) => (


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

- I think it'd be helpful to have the week day displayed. Newcomers might not realize that events are always on a Thursdays (saves a trip to the calendar) and regulars might miss the one time we have to switch to a different week day.
- Year, well, I'm just being optimistic this will last forever :)
- I moved away from the intl-aware format because we're forcing it to be US anyway, and I found `Thursday, July 25, 2024` to be quite silly. "25 July 2024" is a date format I often see on standards, such as https://www.w3.org/TR/css/. Let me know if there is a better way to do this.

Thoughts?

<img width="722" alt="Screenshot 2024-07-26 at 01 18 39" src="https://github.com/user-attachments/assets/19953e7e-8779-43a5-94ea-5d202b59fdbf">
