### PR TITLE
chore: remove Renovate `internalChecksFilter` override (with default value)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"automerge": true,
-	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
 	"minimumReleaseAge": "3 days",
 	"postUpdateOptions": ["pnpmDedupe"]


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This is actually the default value: https://docs.renovatebot.com/configuration-options/#internalchecksfilter