### PR TITLE
format

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,12 +1,12 @@
 jobs:
-  prettier:
+  lint_format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
-      - run: pnpm format --list-different
+      - run: pnpm lint:format
 
-name: Prettier
+name: Lint Format
 
 on:
   pull_request: ~

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"dev": "remix vite:dev",
 		"format": "prettier --cache --write .",
 		"lint": "eslint . .*js --max-warnings 0",
+		"lint:format": "prettier --cache --check .",
 		"lint:knip": "knip",
 		"lint:md": "markdownlint \"**/*.md\" \".github/**/*.md\" --rules sentences-per-line",
 		"lint:packages": "pnpm dedupe --check",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"build": "remix vite:build",
 		"dev": "remix vite:dev",
-		"format": "prettier --write .",
+		"format": "prettier --cache --write .",
 		"lint": "eslint . .*js --max-warnings 0",
 		"lint:knip": "knip",
 		"lint:md": "markdownlint \"**/*.md\" \".github/**/*.md\" --rules sentences-per-line",


### PR DESCRIPTION
- **chore(format): use cache**
- **refactor(lint:format): rename workflow**

<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

First commit makes subsequent format command faster for local development.

I am happy to remove second commit, but I think it makes it more clear that you need to have proper formatting to pass linting. I also thinks it more clear that prettier is just a formatter, and there are others :)

🐢
<!-- Description of what is changed and how the code change does that. -->
