### PR TITLE
fix: use correct talk title for November 2024

### DIFF
--- a/app/data/events.json
+++ b/app/data/events.json
@@ -10,7 +10,7 @@
 					"name": "Tamara Puskarevic",
 					"url": "https://www.linkedin.com/in/tamarapuskarevic"
 				},
-				"title": "Design Isn't Scary"
+				"title": "Product testing: Verification and Validation"
 			},
 			{
 				"author": {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Follow-up of https://github.com/SquiggleTools/boston-ts-website/pull/348, title from the October talk was accidentally used.
