### PR TITLE
feat: update Rebecca Miller's talk name for January 16 event

### DIFF
--- a/app/data/events.json
+++ b/app/data/events.json
@@ -17,7 +17,7 @@
 					"name": "Rebecca Miller",
 					"url": "https://www.linkedin.com/in/rebecca-millerr/"
 				},
-				"title": "Design Systems"
+				"title": "Beyond Buttons: The Dark (and Delightful) Side of Design Systems"
 			}
 		]
 	},


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates the name of Rebecca Miller's (my) talk at the January 16, 2025 TS meetup, to its final name.

🤘 
