### PR TITLE
feat: add duration of talks to `/speak` page

### DIFF
--- a/app/routes/speak.tsx
+++ b/app/routes/speak.tsx
@@ -37,8 +37,8 @@ export default function About() {
 					Present a dry run of your talk the week before, so we can check it for
 					accessibility issues and make sure it runs to the expected duration:
 					<ul>
-						<li>Main talk: ~20 minutes</li>
-						<li>Lightning talk: ~10 minutes</li>
+						<li>Full-length talk: about 20 to 30 minutes</li>
+						<li>Lightning talk: about 5 to 10 minutes</li>
 					</ul>
 				</li>
 				<li>Arrive at the meetup before it starts</li>


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #376
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/boston-ts-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds duration of the talks as a subordered list, piggybacking off the "expected duration" bullet.  📣

Should all of the bullets be filled? Being aware of the pending redesign, not sure if the default alternating hollow/filled subordered list behavior is something that should be kept.

### Screenshot

<img width="783" alt="Screenshot of the result of this PR" src="https://github.com/user-attachments/assets/09d55c73-5f82-4c4c-b46f-2e071009948d" />