### PR TITLE
style: add border separating main from nav

### DIFF
--- a/app/components/Layout.css.ts
+++ b/app/components/Layout.css.ts
@@ -81,7 +81,9 @@ export const dot = style({
 export const main = style({
 	"@media": {
 		[breakpoints.medium]: {
+			borderRight: `1rem solid ${vars.color.blue}`,
 			margin: "0",
+			paddingRight: "1rem",
 		},
 	},
 	flexGrow: "9001",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to boston-ts-website! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/boston-ts-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

**Before:**
* No clear visual separation between content and header/footer
* Disorienting when you scroll because of the lack of separation


https://github.com/user-attachments/assets/e7961eab-754a-4b75-8361-b170dfe0fc16

**After:**
* Clear visual separation of content and header/footer
* Not disorienting when you scroll because the sections are separated

https://github.com/user-attachments/assets/5bfb1ed1-b80a-4d14-bfc1-bd82f0eacc03

Note that because a breakpoint is used, the border does not appear in single column mode.

<img width="657" height="565" alt="Screenshot of the Code of Conduct page in single column mode with unaltered appearance" src="https://github.com/user-attachments/assets/f9f50d7a-8cb4-4f4b-ab2d-539b666a5f99" />

🟦 