### PR TITLE
feat: add Laird Dornin's link to August 2026 event

### DIFF
--- a/app/data/events.json
+++ b/app/data/events.json
@@ -14,7 +14,8 @@
 			},
 			{
 				"author": {
-					"name": "Laird Dornin"
+					"name": "Laird Dornin",
+					"url": "https://structable.ai"
 				},
 				"title": "Structable.ai: Schema-first Infrastructure for Agentic AI"
 			}


### PR DESCRIPTION
Adds Laird Dornin's primary link (structable.ai) to his August 2026 talk, following up on #418.